### PR TITLE
PC/모바일 사용성 개선

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
             <div id="pledges"></div>
             <div id="pledges_gotop" onclick="moveToTop();">
                 <div><img src="./img/arrow_up.png" alt="위로 화살표" /></div>
-                <div id="gotop_message">관심분야를 선택하세요</div>
+                <div id="gotop_message">맨 위로 돌아가기</div>
             </div>
         </main>
 

--- a/index.html
+++ b/index.html
@@ -37,11 +37,13 @@
         <title>공약한판정리 - 기호1번 이재명</title>
     </head>
     <body>
-        <header id="header" onclick="reloadPage();">
+        <header id="header">
             <div class="title">
-                <img class="logo" src="./img/logo_jm.png" alt="이재명" />
-                <img class="title" src="./img/title_jm.png" alt="공약한판정리" />
-                <span class="subtitle">기호<span class="charnum">1</span>번 이재명</span>
+                <a href="/">
+                    <img class="logo" src="./img/logo_jm.png" alt="이재명" />
+                    <img class="title" src="./img/title_jm.png" alt="공약한판정리" />
+                    <span class="subtitle">기호<span class="charnum">1</span>번 이재명</span>
+                </a>
             </div>
         </header>
 
@@ -63,7 +65,6 @@
             <div id="pledges_gotop" onclick="moveToTop();">
                 <div><img src="./img/arrow_up.png" alt="위로 화살표" /></div>
                 <div id="gotop_message">관심분야를 선택하세요</div>
-                <div id="pledges_gotop_tags"></div>
             </div>
         </main>
 
@@ -79,7 +80,7 @@
                     <img src="./img/icon_link.png" alt="웹사이트 주소 공유하기" /></a>
             </div>
             <div>
-                이 웹사이트는 공개된 정보를 사용합니다. 
+                이 웹사이트는 공개된 정보를 사용합니다.<br />
                 오픈된 소스 확인 및 제안은 <a href="https://github.com/p4u-jm/p4u-jm.github.io" target="_blank" rel="noopener noreferrer">GitHub 저장소</a>를 확인하세요.
             </div>            
             <div class="credit">

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         <main>
             <div id="pledges_message"></div>
             <div id="pledges">
-                <div class="label">관심분야를 선택하세요</div>
+                <div class="pledge_label">관심분야를 선택하세요</div>
             </div>
         </main>
 

--- a/index.html
+++ b/index.html
@@ -61,7 +61,9 @@
         
         <main>
             <div id="pledges_message"></div>
-            <div id="pledges"></div>
+            <div id="pledges">
+                <div class="label">관심분야를 선택하세요</div>
+            </div>
             <div id="pledges_gotop" onclick="moveToTop();">
                 <div><img src="./img/arrow_up.png" alt="위로 화살표" /></div>
                 <div id="gotop_message">맨 위로 돌아가기</div>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
                     우리지역
                 </div>
             </div>
-            <div id="tags"></div>
+            <div id="tags" class="tags"></div>
         </nav>
         
         <main>
@@ -64,11 +64,16 @@
             <div id="pledges">
                 <div class="label">관심분야를 선택하세요</div>
             </div>
-            <div id="pledges_gotop" onclick="moveToTop();">
-                <div><img src="./img/arrow_up.png" alt="위로 화살표" /></div>
-                <div id="gotop_message">맨 위로 돌아가기</div>
-            </div>
         </main>
+
+        <nav>
+            <div id="tags2" class="tags"></div>
+        </nav>
+
+        <div id="pledges_gotop" onclick="moveToTop();">
+            <div><img src="./img/arrow_up.png" alt="위로 화살표" /></div>
+            <div id="gotop_message">맨 위로 돌아가기</div>
+        </div>
 
         <footer>
             <div class="sharing">

--- a/script/render.js
+++ b/script/render.js
@@ -26,6 +26,7 @@ const renderNav = (selected_tag) => {
     tags = Array.from(tags)
     
     document.getElementById("tags").innerHTML = renderTags(tags, selected_tag)
+    document.getElementById("tags2").innerHTML = renderTags(tags, selected_tag)
     // document.getElementById("pledges_gotop_tags").innerHTML = renderTagsStatic(tags)
 }
 

--- a/script/render.js
+++ b/script/render.js
@@ -282,7 +282,6 @@ const selectSection = (section) => {
             element_1.setAttribute("class", "section_normal")
             
             fetchData("./data/pledges_interest.csv").then((successMessage) => {
-                console.log(successMessage)
                 render("")
             })
 
@@ -302,7 +301,6 @@ const selectSection = (section) => {
             element_message.innerText = "우리지역을 선택하세요"
             
             fetchData("./data/pledges_region.csv").then((successMessage) => {
-                console.log(successMessage)
                 render("")
             })
 

--- a/script/render.js
+++ b/script/render.js
@@ -298,7 +298,6 @@ const selectSection = (section) => {
         case 1:
             element_0.setAttribute("class", "section_normal")
             element_1.setAttribute("class", "section_selected")
-            element_message.innerText = "우리지역을 선택하세요"
             
             fetchData("./data/pledges_region.csv").then((successMessage) => {
                 render("")

--- a/script/render.js
+++ b/script/render.js
@@ -87,87 +87,89 @@ const renderBody = (selected_tag) => {
     var element_html = ""
     var index_element = 0
 
-    filterPledges(selected_tag).forEach(pledge => {
+    if (selected_tag) {
+        filterPledges(selected_tag).forEach(pledge => {
 
-        var element_child = ""
-        element_child = `<div class="pledge" id="pledge_${index_element}">`
+            var element_child = ""
+            element_child = `<div class="pledge" id="pledge_${index_element}">`
 
-        let website_url = ( pledge.website_url.trim() !== "") ? pledge.website_url : "#"
+            let website_url = ( pledge.website_url.trim() !== "") ? pledge.website_url : "#"
 
-        element_child = element_child + `
-            <div class="pledge_expandable" onclick="expandPledge(${index_element})">
-                <div class="pledge_intro">
-                    <div class="pledge_text">
-                        <div class="pledge_location">    
-                            ${pledge.location}
-                        </div>
-                        <div class="pledge_title">    
-                            ${pledge.title}
-                        </div>
-                        <div class="pledge_description">
-                            ${pledge.description}
+            element_child = element_child + `
+                <div class="pledge_expandable" onclick="expandPledge(${index_element})">
+                    <div class="pledge_intro">
+                        <div class="pledge_text">
+                            <div class="pledge_location">    
+                                ${pledge.location}
+                            </div>
+                            <div class="pledge_title">    
+                                ${pledge.title}
+                            </div>
+                            <div class="pledge_description">
+                                ${pledge.description}
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class="pledge_more" id="more_${index_element}" onclick="expandPledge(${index_element})">
-                    <img src="./img/plus.png" alt="더 자세한 내용 열어보기" />
-                </div>
-            </div>
-            `
-
-        element_child = element_child + `<div class="links" id="link_${index_element}" >`
-
-        if ( pledge.image_name.trim() !== "") {
-
-            let youtube_url_array  = pledge.youtube_url.split('/')
-            let youtube_key = youtube_url_array.pop()
-
-            element_child = element_child + `
-                <div>
-                    <img src="${pledge.image_name}" alt="${pledge.title} 설명 그림" />
+                    <div class="pledge_more" id="more_${index_element}" onclick="expandPledge(${index_element})">
+                        <img src="./img/plus.png" alt="더 자세한 내용 열어보기" />
+                    </div>
                 </div>
                 `
-        }
 
-        if ( pledge.youtube_url.trim() !== "") {
+            element_child = element_child + `<div class="links" id="link_${index_element}" >`
 
-            let youtube_url_array  = pledge.youtube_url.split('/')
-            let youtube_key = youtube_url_array.pop()
+            if ( pledge.image_name.trim() !== "") {
+
+                let youtube_url_array  = pledge.youtube_url.split('/')
+                let youtube_key = youtube_url_array.pop()
+
+                element_child = element_child + `
+                    <div>
+                        <img src="${pledge.image_name}" alt="${pledge.title} 설명 그림" />
+                    </div>
+                    `
+            }
+
+            if ( pledge.youtube_url.trim() !== "") {
+
+                let youtube_url_array  = pledge.youtube_url.split('/')
+                let youtube_key = youtube_url_array.pop()
+
+                element_child = element_child + `
+                    <div>
+                        <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/${youtube_key}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                    </div>
+                    `
+            }
+
+            if ( pledge.website_url.trim() !== "") {
+
+                element_child = element_child + `
+                    <div class="link_website">
+                        <a href="${pledge.website_url}" target="_blank" rel="noopener noreferrer">
+                            내용 더 보기
+                            <img src="./img/outlink.png" alt="내용 더 보기 링크 열기" />
+                        </a>
+                    </div>
+                    `
+            }
 
             element_child = element_child + `
-                <div>
-                    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/${youtube_key}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                    <div class="pledge_fold" onclick="foldPledge(${index_element})">
+                        <img src="./img/arrow_up.png" alt="공약 내용 간단히 보도록 접기" />
+                        접기
+                    </div>
                 </div>
                 `
-        }
+            element_child = element_child + `</div>`
 
-        if ( pledge.website_url.trim() !== "") {
+            element_html = element_html + element_child
 
-            element_child = element_child + `
-                <div class="link_website">
-                    <a href="${pledge.website_url}" target="_blank" rel="noopener noreferrer">
-                        내용 더 보기
-                        <img src="./img/outlink.png" alt="내용 더 보기 링크 열기" />
-                    </a>
-                </div>
-                `
-        }
+            index_element++
+        })
 
-        element_child = element_child + `
-                <div class="pledge_fold" onclick="foldPledge(${index_element})">
-                    <img src="./img/arrow_up.png" alt="공약 내용 간단히 보도록 접기" />
-                    접기
-                </div>
-            </div>
-            `
-        element_child = element_child + `</div>`
-
-        element_html = element_html + element_child
-
-        index_element++
-    })
-
-    document.getElementById("pledges").innerHTML = element_html
+        document.getElementById("pledges").innerHTML = element_html
+    }
 }
 
 const selectTag = (tag) => {

--- a/script/render.js
+++ b/script/render.js
@@ -26,7 +26,7 @@ const renderNav = (selected_tag) => {
     tags = Array.from(tags)
     
     document.getElementById("tags").innerHTML = renderTags(tags, selected_tag)
-    document.getElementById("pledges_gotop_tags").innerHTML = renderTagsStatic(tags)
+    // document.getElementById("pledges_gotop_tags").innerHTML = renderTagsStatic(tags)
 }
 
 const renderTags = (tags, selected_tag) => {
@@ -262,10 +262,6 @@ const foldPledge = (index) => {
     scrollToElement(element)
 }
 
-const reloadPage = () => {
-    location.href = "./index.html"
-}
-
 const scrollToElement = (element) => {
     if (window.safari !== undefined) {
         element.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -284,7 +280,6 @@ const selectSection = (section) => {
         case 0:
             element_0.setAttribute("class", "section_selected")
             element_1.setAttribute("class", "section_normal")
-            element_message.innerText = "관심분야를 선택하세요"
             
             fetchData("./data/pledges_interest.csv").then((successMessage) => {
                 console.log(successMessage)

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -83,6 +83,9 @@ nav .sections {
     margin-bottom: 10px;
     text-align: center;
     text-align: center;
+    user-select: none;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
 
     width: 100%;
     border-radius: 5px;
@@ -95,6 +98,7 @@ nav .sections div {
 
     position: relative;
     display: inline-block;
+    user-select: none;
 
     margin-left: 5px;
     margin-right: 5px;
@@ -156,6 +160,8 @@ nav .section_normal:hover {
     font-size: medium;
     transition: 0.25s;
     margin: 4px 4px 4px 4px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
 
     border-radius: 50vh;
 }
@@ -221,6 +227,7 @@ nav .section_normal:hover {
 }
 
 .pledge_expandable {
+    cursor: pointer;
     padding: 5px;
     margin: 5px;
 }
@@ -328,6 +335,7 @@ nav .section_normal:hover {
     text-align: center;
     padding-top: 10px;
     padding-bottom: 10px;
+    cursor: pointer;
 }
 
 .pledge_fold img {
@@ -345,6 +353,7 @@ nav .section_normal:hover {
     border-color: lightgray;
     transition: 0.25s;
     color: #00A0E2;
+    cursor: pointer;
 }
 
 #pledges_gotop:hover {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -354,7 +354,6 @@ nav .section_normal:hover {
     border-style: dotted;
     border-color: lightgray;
     transition: 0.25s;
-    color: #00A0E2;
     cursor: pointer;
 }
 
@@ -442,4 +441,11 @@ footer .credit a {
 
 footer .credit {
     margin-bottom: 25px;
+}
+
+.label {
+    margin-top: -80px;
+    margin-bottom: 80px;
+    text-align: center;
+    color: #00A0E2;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -143,7 +143,7 @@ nav .section_normal:hover {
     border-radius: 10px;
 }
 
-#tags {
+.tags {
     clear: both;
     /* margin-top: 25px; */
     /* white-space: nowrap;
@@ -151,7 +151,7 @@ nav .section_normal:hover {
     margin: 5px;
 }
 
-#tags button {
+.tags button {
     position: relative;
     display: inline-block;
     border: none;
@@ -445,7 +445,11 @@ footer .credit {
 
 .label {
     margin-top: -80px;
-    margin-bottom: 80px;
+    margin-bottom: 160px;
     text-align: center;
     color: #00A0E2;
+}
+
+#tags2 {
+    margin-top: 40px;;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -230,6 +230,7 @@ nav .section_normal:hover {
     cursor: pointer;
     padding: 5px;
     margin: 5px;
+    -webkit-tap-highlight-color: transparent;
 }
  
 .pledge_intro {
@@ -276,6 +277,7 @@ nav .section_normal:hover {
 
 .pledge_more {
     text-align: center;
+    -webkit-tap-highlight-color: transparent;
 }
 
 .pledge_more img {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -166,6 +166,10 @@ nav .section_normal:hover {
     border-radius: 50vh;
 }
 
+#tags2 {
+    margin-top: 40px;;
+}
+
 .tag {
     color: #3982C1;
     background-color: #F2F9FE;
@@ -224,6 +228,13 @@ nav .section_normal:hover {
 
 .pledge:hover {
     background-color: #E3F1FD;
+}
+
+.pledge_label {
+    margin-top: -80px;
+    margin-bottom: 160px;
+    text-align: center;
+    color: #00A0E2;
 }
 
 .pledge_expandable {
@@ -443,13 +454,3 @@ footer .credit {
     margin-bottom: 25px;
 }
 
-.label {
-    margin-top: -80px;
-    margin-bottom: 160px;
-    text-align: center;
-    color: #00A0E2;
-}
-
-#tags2 {
-    margin-top: 40px;;
-}


### PR DESCRIPTION
|변경 전|변경 후|
|-|-|
|![image](https://user-images.githubusercontent.com/46562466/156001155-1b06d9e6-c67d-4ecd-96f0-b7d8cfe59296.png)|![image](https://user-images.githubusercontent.com/46562466/156000383-abc0b84b-d80d-46c3-b6e7-ce0345f38b08.png)|



[저번 PR](https://github.com/p4u-jm/p4u-jm.github.io/pull/2) 에서 지적해주셨던 "첫 화면에서 관심분야 선택을 유도"와 "확인 후에도 다른 분야 선택을 유도"에 대한 내용을 수정하였습니다.

첫 화면 관심분야 선택 유도는 라벨로, 확인 후 다른 분야 선택 유도는 하단 태그로 해결하였습니다.

1. 위로 가기 버튼의 라벨을 수정함으로써, 이 버튼이 "위로 가기"를 뜻하는 것을 분명히 했습니다.
2. 첫 선택 유도는 페이지에서 가장 눈에 띄는 컴포넌트 아래에 위치 시켜서 눈에 잘 띄게 했습니다.
3. 다른 선택 유도는 하단에도 태그 선택을 추가하여 해결했습니다. 대부분의 경우에서 사용자는 "관심 분야" 에서 "우리 지역"으로 이동하기 보다는 한 카테고리 내에서 다른 태그를 검색하며 사이트를 탐색할 것으로 예상되므로, 굳이 위로 올라가서 다시 선택하기 보다는 아예 하단에서 다른 태그로 이동할 수 있도록 하였습니다.